### PR TITLE
Consider penalty factor for elements in the same group

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    vns (0.3.0)
+    vns (1.0.pre.rc.1)
       activesupport
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -15,11 +15,11 @@ GEM
       zeitwerk (~> 2.3)
     ast (2.4.1)
     coderay (1.1.3)
-    concurrent-ruby (1.1.8)
-    i18n (1.8.7)
+    concurrent-ruby (1.1.9)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.14.3)
+    minitest (5.15.0)
     parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
@@ -45,7 +45,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.4)
 
 PLATFORMS
   ruby

--- a/lib/vns/person.rb
+++ b/lib/vns/person.rb
@@ -1,13 +1,14 @@
 module VNS
   class Person
-    attr_reader :id, :name
-    def initialize(id, name)
+    attr_reader :id, :name, :group
+    def initialize(id, name, group)
       @id = id
       @name = name
+      @group = group
     end
 
     def to_s
-      "#{id}\t#{name}"
+      "#{id}\t#{name} (#{group})"
     end
   end
 end

--- a/lib/vns/version.rb
+++ b/lib/vns/version.rb
@@ -1,3 +1,3 @@
 module VNS
-  VERSION = '0.3.0'
+  VERSION = '1.0-rc.1'
 end


### PR DESCRIPTION
### What

In addition to taking into account the individual happiness (difference between the preferred session and the session assigned), we want to consider a penalty for members in the same group having the same session assigned. The goal is to distribute the assignment of sessions evenly between groups, while keeping individual preferences. 

A `group_duplication_factor = 0` would not care about people in the same group being assigned to the same session, and bigger values would incrementally balance the solution towards spreading members from the same group into different sessions, disregarding individual preferences.